### PR TITLE
add the common name string instead of the match instance in domains set

### DIFF
--- a/sign_csr.py
+++ b/sign_csr.py
@@ -59,7 +59,7 @@ def sign_csr(pubkey, csr):
     domains = set([])
     common_name = re.search("Subject:.*? CN=([^\s,;/]+)", out)
     if common_name is not None:
-        domains.add(common_name)
+        domains.add(common_name.group(1))
     subject_alt_names = re.search("X509v3 Subject Alternative Name: \n +([^\n]+)\n", out, re.MULTILINE|re.DOTALL)
     if subject_alt_names is not None:
         for san in subject_alt_names.group(1).split(", "):


### PR DESCRIPTION
Without this modification, I would get an exception when it tries to print the common name:

```
$ python2 sign_csr.py user.pub bidule.csr                               
Reading pubkey file...
Found public key!
Reading csr file...
Traceback (most recent call last):
  File "sign_csr.py", line 366, in <module>
    signed_crt = sign_csr(args.pubkey_path, args.csr_path)
  File "sign_csr.py", line 68, in sign_csr
    sys.stderr.write("Found domains {}\n".format(", ".join(domains)))
TypeError: sequence item 1: expected string, _sre.SRE_Match found
```

I am using Python 2.7.10

Thanks for the script by the way, I will probably use it when let's encrypt is ready.
