### PR TITLE
use ENV var placeholders and user account key in help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ step.
 
 ```sh
 openssl genrsa 4096 > user.key
-openssl rsa -in user.key -pubout > user.pub
+openssl rsa -in user.key -pubout > user.key.pub
 ```
 
 Second, you need to generate the domain key and a certificate request.
@@ -79,7 +79,7 @@ Third, you run the script using python and passing in the path to your user
 account public key and the domain CSR. The paths can be relative or absolute.
 
 ```sh
-python sign_csr.py --public-key user.pub domain.csr > signed.crt
+python sign_csr.py --public-key user.key.pub domain.csr > signed.crt
 ```
 
 When you run the script, it will ask you do do some manual commands. It has to
@@ -119,10 +119,10 @@ Prerequisites:
 Example: Generate an account keypair, a domain key and csr, and have the domain csr signed.
 --------------
 $ openssl genrsa 4096 > user.key
-$ openssl rsa -in user.key -pubout > user.pub
+$ openssl rsa -in user.key -pubout > user.key.pub
 $ openssl genrsa 4096 > domain.key
 $ openssl req -new -sha256 -key domain.key -subj "/CN=example.com" > domain.csr
-$ python sign_csr.py --public-key user.pub domain.csr > signed.crt
+$ python sign_csr.py --public-key user.key.pub domain.csr > signed.crt
 --------------
 
 positional arguments:
@@ -131,7 +131,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -p PUBLIC_KEY, --public-key PUBLIC_KEY
-                        path to your account public key
+                        path to your user account public key
   -e EMAIL, --email EMAIL
                         contact email, default is webmaster@<shortest_domain>
 user@hostname:~$
@@ -146,7 +146,7 @@ Generating RSA private key, 4096 bit long modulus
 .............................................................................................................................................................................++
 ....................................................++
 e is 65537 (0x10001)
-user@hostname:~$ openssl rsa -in user.key -pubout > user.pub
+user@hostname:~$ openssl rsa -in user.key -pubout > user.key.pub
 writing RSA key
 user@hostname:~$ openssl genrsa 4096 > domain.key
 Generating RSA private key, 4096 bit long modulus
@@ -154,7 +154,7 @@ Generating RSA private key, 4096 bit long modulus
 ...........................................++
 e is 65537 (0x10001)
 user@hostname:~$ openssl req -new -sha256 -key domain.key -subj "/CN=letsencrypt.daylightpirates.org" > domain.csr
-user@hostname:~$ python sign_csr.py --public-key user.pub domain.csr > signed.crt
+user@hostname:~$ python sign_csr.py --public-key user.key.pub domain.csr > signed.crt
 Reading pubkey file...
 Found public key!
 Reading csr file...

--- a/sign_csr.py
+++ b/sign_csr.py
@@ -181,17 +181,18 @@ def sign_csr(pubkey, csr, email=None):
 
     # Step 5: Ask the user to sign the registration and requests
     sys.stderr.write("""\
-STEP 2: You need to sign some files (replace 'user.key' with your user private key).
+STEP 2: You need to sign some files (replace ./user.key with the path to your user account private key).
 
-openssl dgst -sha256 -sign user.key -out {} {}
+export PRIVATE_USER_KEY=./user.key
+openssl dgst -sha256 -sign $PRIVATE_USER_KEY -out {} {}
 {}
 {}
-openssl dgst -sha256 -sign user.key -out {} {}
+openssl dgst -sha256 -sign $PRIVATE_USER_KEY -out {} {}
 
 """.format(
     reg_file_sig_name, reg_file_name,
-    "\n".join("openssl dgst -sha256 -sign user.key -out {} {}".format(i['sig_name'], i['file_name']) for i in ids),
-    "\n".join("openssl dgst -sha256 -sign user.key -out {} {}".format(i['sig_name'], i['file_name']) for i in tests),
+    "\n".join("openssl dgst -sha256 -sign $PRIVATE_USER_KEY -out {} {}".format(i['sig_name'], i['file_name']) for i in ids),
+    "\n".join("openssl dgst -sha256 -sign $PRIVATE_USER_KEY -out {} {}".format(i['sig_name'], i['file_name']) for i in tests),
     csr_file_sig_name, csr_file_name))
 
     stdout = sys.stdout
@@ -280,12 +281,13 @@ openssl dgst -sha256 -sign user.key -out {} {}
 
     # Step 9: Ask the user to sign the challenge responses
     sys.stderr.write("""\
-STEP 3: You need to sign some more files (replace 'user.key' with your user private key).
+STEP 3: You need to sign some more files (replace ./user.key with the path to your user account private key).
 
+export PRIVATE_USER_KEY=./user.key
 {}
 
 """.format(
-    "\n".join("openssl dgst -sha256 -sign user.key -out {} {}".format(
+    "\n".join("openssl dgst -sha256 -sign $PRIVATE_USER_KEY -out {} {}".format(
         i['sig_name'], i['file_name']) for i in responses)))
 
     stdout = sys.stdout
@@ -411,19 +413,19 @@ Prerequisites:
 * openssl
 * python
 
-Example: Generate an account keypair, a domain key and csr, and have the domain csr signed.
+Example: Generate an user account keypair, a domain key and csr, and have the domain csr signed.
 --------------
 $ openssl genrsa 4096 > user.key
-$ openssl rsa -in user.key -pubout > user.pub
+$ openssl rsa -in user.key -pubout > user.key.pub
 $ openssl genrsa 4096 > domain.key
 $ openssl req -new -sha256 -key domain.key -subj "/CN=example.com" > domain.csr
 $ python sign_csr.py --public-key user.pub domain.csr > signed.crt
 --------------
 
 """)
-    parser.add_argument("-p", "--public-key", required=True, help="path to your account public key")
+    parser.add_argument("-p", "--public-key", required=True, help="path to your user account user.key.pub key")
     parser.add_argument("-e", "--email", default=None, help="contact email, default is webmaster@<shortest_domain>")
-    parser.add_argument("csr_path", help="path to your certificate signing request")
+    parser.add_argument("csr_path", help="path to your domain certificate signing request")
 
     args = parser.parse_args()
     signed_crt = sign_csr(args.public_key, args.csr_path, email=args.email)


### PR DESCRIPTION
Discussion for this PR is in issue #11 

```
    modified:   README.md
modified:   sign_csr.py
```
